### PR TITLE
travis.yml integration to run the basic tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+dist: trusty
+language: node_js
+node_js:
+  - 6
+
+before_install:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+before_script:
+  - npm run build
+
+script:
+  - npm run test
+  
+cache:
+  directories: node_modules
+
+# safelist
+branches:
+  only:
+  - master


### PR DESCRIPTION
fixes issue #15 
I have integrated `travis.yml` to run basic tests. Will update travis for auto-deployment on gh pages once issue with generation of `index.html` gets solved. issue #37

